### PR TITLE
Timeout increase

### DIFF
--- a/libraries/pfx.rb
+++ b/libraries/pfx.rb
@@ -75,10 +75,10 @@ module WindowsCert
     def wait_for_output
       timeout = 0
       until File.exist?(out_file)
-        if timeout < 36 # Allow up to 3 minutes to install
+        if timeout < 30 # Allow up to 5 minutes to install
           timeout += 1
           Chef::Log.info('Waiting for cert install script to complete.')
-          sleep(5)
+          sleep(10)
         else
           Chef::Log.error('Install timeout: Task completion log not found.')
           Chef::Log.error('Install timeout: Aborting run.')

--- a/libraries/pfx.rb
+++ b/libraries/pfx.rb
@@ -75,7 +75,7 @@ module WindowsCert
     def wait_for_output
       timeout = 0
       until File.exist?(out_file)
-        if timeout < 18 # Allow up to 90 seconds to install
+        if timeout < 36 # Allow up to 3 minutes to install
           timeout += 1
           Chef::Log.info('Waiting for cert install script to complete.')
           sleep(5)

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ maintainer_email 'sweitzel74@gmail.com'
 license 'all_rights'
 description 'Installs/Configures windows_cert'
 long_description 'Installs/Configures windows_cert'
-version '0.2.1'
+version '0.2.2'
 
 depends  'windows', '~> 1.38'
 supports 'windows'


### PR DESCRIPTION
- [ ] @sweitzel74 

- Dealing with some EC2 nodes (t2.medium) that are a bit slow at times.  This PR increases the timeout allowed to install a cert.